### PR TITLE
Fixed leaked HTTP response body when fetching config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ captures/
 
 # Keystore files
 *.jks
+
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ configurations {
 }
 
 group = "io.outbound.sdk"
-version = "0.2.6"
+version = "0.2.7"
 def siteUrl = 'https://outboundio.github.io/android-sdk'
 def gitUrl = 'https://github.com/outboundio/android-sdk.git'
 

--- a/src/main/java/io/outbound/sdk/OutboundRequest.java
+++ b/src/main/java/io/outbound/sdk/OutboundRequest.java
@@ -204,7 +204,9 @@ class OutboundRequest {
     public void onSuccess(Response response) throws IOException {
         switch (request) {
             case CONFIG:
-                OutboundClient.getInstance().setConfig(response.body().string());
+                String body = response.body().string();
+                response.body().close();
+                OutboundClient.getInstance().setConfig(body);
                 break;
         }
     }


### PR DESCRIPTION
Fixed a leaked HTTP response body when fetching the SDK config on first launch.

This would previously output warnings like:
```
[OkHttp] A connection to https://api.outbound.io/ was leaked. Did you forget to close a response body? 
```
As per http://square.github.io/okhttp/3.x/okhttp/index.html?okhttp3/ResponseBody.html:
> The response body must be closed.
