### PR TITLE
Bump version to 0.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ configurations {
 }
 
 group = "io.outbound.sdk"
-version = "0.2.7"
+version = "0.2.8"
 def siteUrl = 'https://outboundio.github.io/android-sdk'
 def gitUrl = 'https://github.com/outboundio/android-sdk.git'
 


### PR DESCRIPTION
New release drops the `android.permission.GET_ACCOUNTS` permission.