### PR TITLE
Close ResponseBody in error cases

### DIFF
--- a/src/main/java/io/outbound/sdk/OutboundRequest.java
+++ b/src/main/java/io/outbound/sdk/OutboundRequest.java
@@ -196,6 +196,9 @@ class OutboundRequest {
     }
 
     public void onError(Response response) {
+        if (response.body() != null) {
+            response.body().close();
+        }
         if (request == Type.CONFIG) {
             OutboundClient.getInstance().loadConfig(attempts);
         }


### PR DESCRIPTION
> W/OkHttp: A connection to https://api.outbound.io/ was leaked. Did you forget to close a response body?

This is still present in version 0.2.8. As it is stated numerous times in [OkHttp#2311](https://github.com/square/okhttp/issues/2311), the body has to be closed in error cases too.