### PR TITLE
Remove the DISPLAY_NOTIF intent

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,88 @@
+# Migrating from Outbound Android SDK 0.3.X to 0.4.X
+
+## Removed Notification Display Intent
+Outbound Notifications will now be displayed immediately once received without using an intent to trigger its display.
+
+### OutboundMessagingService changes
+
+`OutboundMessagingService` now provides 3 methods which can be overriden with your own extended classes:
+- `public void onReceivedMessage(RemoteMessage message)` - Called when an unhandled non-Outbound notification is received
+- `public void onNotificationReceived(PushNotification notification)` - Called after an Outbound notification is received
+- `public void onNotificationDisplayed(PushNotification notification)` - Called after an Outbound notification is displayed
+- `public Notification buildNotification(PushNotification notification)` - Called to create an Android `Notification` from a `PushNotification`. Can be used to create custom notification styling.
+
+For example:
+```java
+public class DebugMessagingService extends OutboundMessagingService {
+    @Override
+    public void onReceivedMessage(RemoteMessage message) {
+        Log.d("DebugMessagingService", "non-outbound message received " + message.getMessageId());
+    }
+
+    @Override
+    public void onNotificationDisplayed(PushNotification notification) {
+        Log.d("DebugMessagingService", "outbound notification displayed " + notification.getInstanceId());
+    }
+
+    @Override
+    public void onNotificationReceived(PushNotification notification) {
+        Log.d("DebugMessagingService", "outbound notification received " + notification.getInstanceId());
+    }
+
+    @Override
+    public Notification buildNotification(PushNotification notification) {
+        NotificationCompat.Builder notificationBuilder = notification.createNotificationBuilder(this);
+        try {
+            // Use the custom JSON payload from the Campaign to specify your own custom fields
+            if (notification.getPayload().getBoolean("showBigText")) {
+                notificationBuilder.setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(notification.getTitle()));
+            }
+        } catch (Exception e) {
+            // Handle any exceptions here
+        }
+
+        return notificationBuilder.build();
+    }
+}
+```
+
+### OutboundService changes
+`OutboundService` no longer provides an override for `onDisplayNotification`.
+This has been moved to `OutboundMessagingService` and been renamed to `onNotificationDisplayed`.
+
+### AndroidManifest.xml changes
+
+The `OutboundService` service no longer needs an intent filter for displaying notifications.
+
+You need to remove `<action android:name="YOUR_PACKAGE_NAME.outbound.action.DISPLAY_NOTIF" />` from your `AndroidManifest.xml`.
+
+#### Before:
+
+```xml
+<service
+  android:name="io.outbound.sdk.OutboundService"
+  android:exported="false"
+  android:label="OutboundService" >
+  <intent-filter>
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.TRACK_NOTIF" />
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.DISPLAY_NOTIF" />
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.RECEIVED_NOTIF" />
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.OPEN_NOTIF" />
+  </intent-filter>
+</service>
+```
+
+#### After:
+```xml
+<service
+  android:name="io.outbound.sdk.OutboundService"
+  android:exported="false"
+  android:label="OutboundService" >
+  <intent-filter>
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.TRACK_NOTIF" />
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.RECEIVED_NOTIF" />
+    <action android:name="YOUR_PACKAGE_NAME.outbound.action.OPEN_NOTIF" />
+  </intent-filter>
+</service>
+```

--- a/src/main/java/io/outbound/sdk/OutboundIntentHandler.java
+++ b/src/main/java/io/outbound/sdk/OutboundIntentHandler.java
@@ -23,27 +23,12 @@ class OutboundIntentHandler {
         }
 
         PushNotification notif = new PushNotification(extras);
-
-        if (!notif.isSilent()) {
-            if (!extras.containsKey("_onid")) {
-                Log.e(TAG, "Malformed Outbound notification. Ignoring.");
-                return -3;
-            }
-
-            Intent notifIntent = new Intent(context.getPackageName() + OutboundService.ACTION_DISPLAY_NOTIF);
-            notifIntent.setPackage(context.getApplicationContext().getPackageName());
-            notifIntent.putExtra(OutboundService.EXTRA_NOTIFICATION, notif);
-            WakefulBroadcastReceiver.startWakefulService(context, notifIntent);
-        }
-
         if (notif.isTracker()) {
             Intent utIntent = new Intent(context.getPackageName() + OutboundService.ACTION_TRACK_NOTIF);
             utIntent.setPackage(context.getApplicationContext().getPackageName());
             utIntent.putExtra(OutboundService.EXTRA_NOTIFICATION, notif);
             WakefulBroadcastReceiver.startWakefulService(context, utIntent);
-        }
-
-        if (!notif.isTracker()) {
+        } else {
             Intent recvIntent = new Intent(context.getPackageName() + OutboundService.ACTION_RECEIVED_NOTIF);
             recvIntent.setPackage(context.getApplicationContext().getPackageName());
             recvIntent.putExtra(OutboundService.EXTRA_NOTIFICATION, notif);

--- a/src/main/java/io/outbound/sdk/OutboundService.java
+++ b/src/main/java/io/outbound/sdk/OutboundService.java
@@ -1,23 +1,13 @@
 package io.outbound.sdk;
 
 import android.app.IntentService;
-import android.app.Notification;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.media.RingtoneManager;
 import android.net.Uri;
-import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.v4.app.NotificationCompat;
-import android.util.Log;
 
 /**
  * OutboundService handles tasks related to notifications that Outbound sends. OutboundService or a
@@ -32,7 +22,6 @@ import android.util.Log;
  *   android:label="OutboundService" >
  *   <intent-filter>
  *      <action android:name="io.outbound.sdk.action.TRACK_NOTIF" />
- *      <action android:name="io.outbound.sdk.action.DISPLAY_NOTIF" />
  *      <action android:name="io.outbound.sdk.action.RECEIVED_NOTIF" />
  *      <action android:name="io.outbound.sdk.action.OPEN_NOTIF" />
  *   </intent-filter>
@@ -43,7 +32,6 @@ import android.util.Log;
  * actions), you should subclass it and implement on of the public methods.</p>
  *
  * <ul>
- *     <li>{@link #onDisplayNotification(PushNotification)} is called after a notification is displayed.</li>
  *     <li>{@link #onReceiveNotification(PushNotification)} is called after a notification is received. Important
  * to note the difference between display and receive. onDisplayNotification will only be called after
  * a notification is DISPLAYED. If you send silent notifications, this will not get called. onReceiveNotification
@@ -77,7 +65,6 @@ public class OutboundService extends IntentService {
 
     // consumers package name should be prepended to each of these actions
     public static final String ACTION_OPEN_NOTIF = ".outbound.action.OPEN_NOTIF";
-    public static final String ACTION_DISPLAY_NOTIF = ".outbound.action.DISPLAY_NOTIF";
     public static final String ACTION_RECEIVED_NOTIF = ".outbound.action.RECEIVED_NOTIF";
     public static final String ACTION_TRACK_NOTIF = ".outbound.action.TRACK_NOTIF";
 
@@ -122,7 +109,6 @@ public class OutboundService extends IntentService {
         String action = intent.getAction();
         String openAction = pkgName + ACTION_OPEN_NOTIF;
         String recvAction = pkgName + ACTION_RECEIVED_NOTIF;
-        String displayAction = pkgName + ACTION_DISPLAY_NOTIF;
         String trackAction = pkgName + ACTION_TRACK_NOTIF;
         if (action.equals(openAction)) {
             if (!notif.isTestMessage()) {
@@ -177,121 +163,6 @@ public class OutboundService extends IntentService {
 
             // TODO handle exceptions? thread?
             onReceiveNotification(notif);
-        } else if (action.equals(displayAction)) {
-            PackageManager pm = getPackageManager();
-            ApplicationInfo appInfo = null;
-            try {
-                appInfo = pm.getApplicationInfo(getApplication().getPackageName(), PackageManager.GET_META_DATA);
-            } catch (PackageManager.NameNotFoundException e) {
-                // since we are using context.getPackageName() this should never happen.
-                Log.e(TAG, "Tried to access app that doesn't exist.");
-            }
-
-            int icon = appInfo.icon;
-
-            BitmapFactory.Options options = new BitmapFactory.Options();
-            options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-
-
-            NotificationCompat.Builder builder;
-            String notificationChannelId = OutboundClient.getInstance().getNotificationChannelId();
-            if (notificationChannelId != null) {
-                builder = new NotificationCompat.Builder(getApplicationContext(), notificationChannelId);
-            } else {
-                builder = new NotificationCompat.Builder(getApplicationContext());
-            }
-
-            if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) && (notificationChannelId == null)) {
-                // Warning: Notifications may not be delivered for Android 8+ (Oreo+) clients
-                // Developers should provide a notification channel id () : https://developer.android.com/guide/topics/ui/notifiers/notifications.html
-                Log.w(TAG, "Did you forget to provide a notification channel id? Notifications may not be delivered on sdk26+");
-            }
-
-            builder
-                .setAutoCancel(true)
-                .setStyle(new NotificationCompat.BigTextStyle().bigText(notif.getBody() == null ? "" : notif.getBody()))
-                .setContentText(notif.getBody() == null ? "" : notif.getBody())
-                .setContentTitle(notif.getTitle() == null ? "" : notif.getTitle())
-                .setSmallIcon(icon);
-
-            try {
-                String image = notif.getSmNotifImage();
-                String folder = notif.getSmNotifFolder();
-                if (folder != "" && image != "") {
-                    int resId = getResources().getIdentifier(image, folder, getApplication().getPackageName());
-                    if (resId != 0) {
-                        builder.setSmallIcon(resId);
-                    }
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Small icon doesn't exist");
-                builder.setSmallIcon(icon);
-            }
-
-            try {
-                String image = notif.getLgNotifImage();
-                String folder = notif.getLgNotifFolder();
-                Resources rs = pm.getResourcesForApplication(getApplication().getPackageName());
-                if (folder != "" && image != "") {
-                    int resId = getResources().getIdentifier(image, folder, getApplication().getPackageName());
-                    if (resId != 0) {
-                        builder.setLargeIcon(BitmapFactory.decodeResource(rs, resId));
-                    }
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Large icon doesn't exist");
-            }
-
-            try {
-                Uri media = null;
-                if (notif.getSoundSilent().equals(true)){
-                } else if (notif.getSoundDefault().equals(true)) {
-                    media = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-                } else {
-                    int resId = getResources().getIdentifier(notif.getSoundFile(), notif.getSoundFolder(), getApplication().getPackageName());
-                    if (resId != 0) {
-                        media = Uri.parse("android.resource://" + getPackageName() + "/" + resId);
-                    }
-                }
-
-                if (media != null) {
-                    builder.setSound(media);
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Music asset does not exist");
-            }
-
-            // we set local only since the server already sends to all device tokens registered.
-            // until we investigate how this works it is better safe than sorry.
-            builder.setLocalOnly(true);
-
-            // TODO implement these
-            // builder.setDeleteIntent(); // notification is cleared
-            // builder.setPriority();
-            // builder.setLights();
-            // builder.setSound();
-
-            Intent intentToOpen = new Intent(getPackageName() + OutboundService.ACTION_OPEN_NOTIF);
-            intentToOpen.setPackage(getApplicationContext().getPackageName());
-            intentToOpen.putExtra(OutboundService.EXTRA_NOTIFICATION, notif);
-
-            PendingIntent pIntent = PendingIntent.getService(getApplicationContext(), 0, intentToOpen, PendingIntent.FLAG_ONE_SHOT);
-            builder.setContentIntent(pIntent);
-
-            if (notif.getCategory() != null) {
-                builder.setCategory(notif.getCategory());
-            }
-
-            Notification notification = builder.build();
-
-            if (notificationManager == null) {
-                this.notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            }
-
-            notificationManager.notify(notif.getId(), notification);
-
-            // TODO handle exceptions? thread?
-            onDisplayNotification(notif);
         } else if (action.equals(trackAction)) {
             if (notif.getInstanceId() != null) {
                 Context ctx = getApplicationContext();
@@ -301,14 +172,6 @@ public class OutboundService extends IntentService {
 
         OutboundPushReceiver.completeWakefulIntent(intent);
     }
-
-    /**
-     * Called after an Outbound notification is displayed. <b>IS NOT</b> called for silent notifications
-     * since they do not "display."
-     *
-     * @param notif
-     */
-    public void onDisplayNotification(PushNotification notif) {}
 
     /**
      * Called after an Outbound notification is clicked and opened. If you want to implement your own


### PR DESCRIPTION
As part of fixing #10, we are revising how Intents are used.

This PR removes using an intent for displaying a notification, instead using `OutboundMessagingService` to display it immediately once a `RemoteNotification` is received.

The [Migration Guide](https://github.com/outboundio/android-sdk/blob/360ed3004aa5e875d9fa0f5ae062f65a9f364035/docs/migrating.md) provides more information on what changes are needed for the new version of the SDK.

### Changes:
1. Removed `X.outbound.action.DISPLAY_NOTIF` intent
2. `OutboundMessagingService` now builds and displays notifications immediately
3. `OutboundMessagingService` now provides an overridable function `buildNotification` to customize how Notifications are built to be displayed
5. `OutboundService` no longer has an overridable `onDisplayNotification` function.
4. `OutboundMessagingService` now provides overridable functions `onNotificationReceived` and `onNotificationDisplayed` to replace `onDisplayNotification` removed from `OutboundService`

### Remaining Work
- Introduce [Firebase Job Dispatcher](https://github.com/firebase/firebase-jobdispatcher-android#user-content-firebase-jobdispatcher-) dependency.
- Remove `TRACK_NOTIF` intent and replace with a Job (with a better name for its purpose).
- Remove `RECEIVED_NOTIF` intent and replace with a Job.
- Update [Android SDK documentation](https://developer.zendesk.com/embeddables/docs/outbound/android)
- Release 0.4.0 version